### PR TITLE
Dropdown fixes: documentation page and default placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 Now you can set a suffix-icon near the default arrow icon
 * Added `text-align` with default value `center` to multiple `Select`'s collapser dropdown
 * Added `optionClass` prop to `Select`
+* `Dropdown` placement was changed from `bottom` to `bottom-start`. Same in `Autocomplete` and `Select` components
 
 ### Maintenance
 * Updated `Notification` component. Do not show browser notifications when window is active
@@ -17,6 +18,7 @@ Now you can set a suffix-icon near the default arrow icon
 * Fixed bug with setting `popperClass` at `dropdownProps` in `Select` and `Autocomplete` components
 * Fixed server sorting in `Table` component
 * `Scrollbar`'s caret containers was updated with z-index
+* Fixed `Dropdown` documentation page
 
 
 

--- a/src/components/autocomplete/script.ts
+++ b/src/components/autocomplete/script.ts
@@ -83,7 +83,7 @@ export default class StAutocomplete extends Vue {
 
   extendedDropdownProps: DropdownBindProperties = {
     arrowVisible: false,
-    placement: PopperPlacement.bottom,
+    placement: PopperPlacement.bottomStart,
     trigger: TriggerType.manual,
     boundariesSelector: 'body',
   };

--- a/src/components/dropdown/script.ts
+++ b/src/components/dropdown/script.ts
@@ -39,7 +39,7 @@ export default class StDropdown extends Vue {
   @Prop({ type: Boolean, default: false })
   arrowVisible!: boolean;
 
-  @Prop({ type: String, default: PopperPlacement.bottom })
+  @Prop({ type: String, default: PopperPlacement.bottomStart })
   placement!: string;
 
   @Prop({ type: Boolean, default: true })

--- a/src/components/dropdown/types.ts
+++ b/src/components/dropdown/types.ts
@@ -1,11 +1,14 @@
-import { TriggerType } from '../popper/types';
+import {
+  PopperPlacement,
+  TriggerType,
+} from '../popper/types';
 
 export interface DropdownBindProperties {
   value?: boolean;
   popperClass?: string;
   width?: number;
   trigger?: TriggerType;
-  placement?: string;
+  placement?: PopperPlacement;
   arrowVisible?: boolean;
   withBorder?: boolean;
   disabled?: boolean;

--- a/src/components/select/_select-dropdown/script.ts
+++ b/src/components/select/_select-dropdown/script.ts
@@ -54,7 +54,7 @@ export default class StSelectDropdown extends Vue {
 
   extendedDropdownProps: DropdownBindProperties = {
     arrowVisible: false,
-    placement: PopperPlacement.bottom,
+    placement: PopperPlacement.bottomStart,
     trigger: TriggerType.click,
     boundariesSelector: 'body',
   };

--- a/stories/documentation/autocomplete.md
+++ b/stories/documentation/autocomplete.md
@@ -72,6 +72,22 @@ onSelect(suggestion) {
 // ...
 ```
 
+Also you can change/extend inner dropdown's props via `dropdown-props`:
+
+```html
+<st-autocomplete placeholder="Enter country name"
+                 prefix-icon="search"
+                 :fetch-suggestions="fetchSuggestions"
+                 v-model="selectedCountry"
+                 :dropdown-props="{
+                    width: 400,
+                    maxHeight: 250,
+                    arrowVisible: true,
+                    placement: 'top',
+                    trigger: 'hover',
+                 }"/>
+```
+
 ## Attributes
 
 | Name | Description | Required | Type | Default value | Possible values |
@@ -92,7 +108,7 @@ onSelect(suggestion) {
 | readonly | Defines readonly property | - | boolean | false | - |
 | placeholder | Search's input placeholder | - | string | - | - |
 | loading | Defines loading state | - | boolean | false | - |
-| dropdown-props | Dropdown popper's component properties | - | object | { arrowVisible: false, placement: bottom, trigger: click, boundariesSelector: 'body', appendToBody: true } | CHECK DROPDOWN COMPONENT DOCUMENTATION |
+| dropdown-props | Dropdown popper's component properties | - | object | { arrowVisible: false, placement: bottom-start, trigger: click, boundariesSelector: 'body', appendToBody: true } | CHECK DROPDOWN COMPONENT DOCUMENTATION |
 
 ## Events
 

--- a/stories/documentation/select.md
+++ b/stories/documentation/select.md
@@ -70,7 +70,7 @@ Here's some examples:
 </st-select>
 ```
 
-Also you can change/extend inner dropdown's props via `dropdown-props` (same with `collapser-popper-props`):
+Also you can change/extend inner dropdown's props via `dropdown-props` (same with `collapser-popper-props` for multiple select):
 
 ```html
 <st-select v-model="singleValue" 
@@ -106,7 +106,7 @@ You can find out more about this component slots in the bottom of documentation.
 | close-on-select | **(Single Select only)** Close dropdown after select event | True | Boolean | False | True / False |
 | show-arrow-icon | Show select's default arrow icon or not | - | Boolean | True | True / False |
 | clear-icon-as-arrow-icon | Use suffix icon as clear icon. It will change suffix icon to cross when input isn't empty | - | Boolean | True | True / False |
-| dropdown-props | Dropdown popper's component properties | - | Object | arrowVisible: false, placement: bottom, trigger: click, boundariesSelector: 'body' | CHECK POPPER COMPONENT DOCUMENTATION |
+| dropdown-props | Dropdown popper's component properties | - | Object | arrowVisible: false, placement: bottom-start, trigger: click, boundariesSelector: 'body' | CHECK POPPER COMPONENT DOCUMENTATION |
 | collapser-popper-props | **(Multiple Select only)** Collapser popper's component properties | - | Object | { arrowVisible: true, placement: top, trigger: hover, boundariesSelector: 'body', appendToBody: true } | CHECK DROPDOWN COMPONENT DOCUMENTATION |
 
 ## Events

--- a/stories/pages/dropdown/default.stories.js
+++ b/stories/pages/dropdown/default.stories.js
@@ -4,11 +4,18 @@ import { template } from '../../templates/dropdown/default.template';
 import documentation from '../../documentation/dropdown.md'
 import { PopperPlacement, TriggerType } from '../../../src/components/popper/types';
 
+let notes = documentation;
+notes = notes.replace('{{DEFAULT_PLACEMENT}}', PopperPlacement.bottomStart);
+notes = notes.replace('{{AVAILABLE_PLACEMENTS}}', Object.values(PopperPlacement).join(', '));
+
+notes = notes.replace('{{DEFAULT_TRIGGER}}', TriggerType.click);
+notes = notes.replace('{{AVAILABLE_TRIGGERS}}', Object.values(TriggerType).join(', '));
+
 storiesOf('Components|Dropdown', module).add('Default', () => ({
   template,
   props: {
     placement: {
-      default: select('placement', Object.values(PopperPlacement), PopperPlacement.bottom)
+      default: select('placement', Object.values(PopperPlacement), PopperPlacement.bottomStart)
     },
     trigger: {
       default: select('trigger', Object.values(TriggerType), TriggerType.click)
@@ -51,5 +58,5 @@ storiesOf('Components|Dropdown', module).add('Default', () => ({
     return {}
   },
 }), {
-  notes: { markdown: documentation },
+  notes: { markdown: notes },
 });

--- a/stories/pages/popper/default.stories.js
+++ b/stories/pages/popper/default.stories.js
@@ -6,10 +6,10 @@ import { PopperPlacement, TriggerType } from "../../../src/components/popper/typ
 
 let notes = documentation;
 notes = notes.replace('{{DEFAULT_PLACEMENT}}', PopperPlacement.auto);
-notes = notes.replace('{{AVAILABLE_PLACEMENTS}}', Object.values(PopperPlacement).join(' , '));
+notes = notes.replace('{{AVAILABLE_PLACEMENTS}}', Object.values(PopperPlacement).join(', '));
 
 notes = notes.replace('{{DEFAULT_TRIGGER}}', TriggerType.hover);
-notes = notes.replace('{{AVAILABLE_TRIGGERS}}', Object.values(TriggerType).join(' , '));
+notes = notes.replace('{{AVAILABLE_TRIGGERS}}', Object.values(TriggerType).join(', '));
 
 storiesOf('Components|Popper', module).add('Default', () => ({
   template,


### PR DESCRIPTION
**Features**
* `Dropdown` placement was changed from `bottom` to `bottom-start`. Same in `Autocomplete` and `Select` components

**Maintenance**
* Fixed `Dropdown` documentation page