### PR TITLE
Fixed multiple Select values displaying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Fixed weird bug when typing in Select leaded to displaying clear icon
 * Fixed `Select` arrow visibility when component is non-clearable
 * Fixed bug with `useReferenceWidth` do not work properly in `Dropdown`
+* Fixed checkbox height (container of checkbox's square was a bit higher)
+* Fixed multiple `Select`'s selected options update. There was a problem with displaying of collapser's items when `Select`'s value was changed from outside
+* Created `BaseSelectValue`, `SingleSelectValue`, and `MultipleSelectValue` types for `Select` prop `value`   
 
 
 

--- a/src/components/checkbox/style.scss
+++ b/src/components/checkbox/style.scss
@@ -25,7 +25,7 @@
   &__inner {
     position: relative;
     box-sizing: border-box;
-    display: inline-block;
+    display: block;
     width: $st-checkbox-width;
     height: $st-checkbox-height;
     border: $st-border-style $st-checkbox-common-border-width $st-checkbox-common-border-color;

--- a/src/components/select/_select-multiple/script.ts
+++ b/src/components/select/_select-multiple/script.ts
@@ -16,7 +16,10 @@ import {
   PopperPlacement,
   TriggerType,
 } from '../../popper/types';
-import { SelectOption } from '../types';
+import {
+  MultipleSelectValue,
+  SelectOption,
+} from '../types';
 
 
 @Component({
@@ -30,7 +33,12 @@ import { SelectOption } from '../types';
 })
 export default class StSelectMultiple extends StSelectBase {
   @Prop(Array)
-  value!: string[];
+  value!: MultipleSelectValue;
+
+  // Extends with onValueChange method from _select.base
+  onValueChange(): void {
+    this.updateSelectedOptions();
+  }
 
   dropdownVisible: boolean = false;
 
@@ -79,7 +87,16 @@ export default class StSelectMultiple extends StSelectBase {
     merge(this.extendedCollapserPopperProps, this.collapserPopperProps);
   }
 
-  updateSelectedOptions(option: SelectOption): void {
+  updateSelectedOptions(): void {
+    this.selectedOptions = this.options.reduce((acc: SelectOption[], option: SelectOption) => {
+      if (this.value.includes(option.value)) {
+        acc.push(option);
+      }
+      return acc;
+    }, []);
+  }
+
+  processSelectedOption(option: SelectOption): void {
     const optionIndex = this.selectedValues.indexOf(option.value);
     if (optionIndex > -1) {
       this.selectedOptions.splice(optionIndex, 1);
@@ -93,7 +110,7 @@ export default class StSelectMultiple extends StSelectBase {
   }
 
   select(option: SelectOption): void {
-    this.updateSelectedOptions(option);
+    this.processSelectedOption(option);
     this.$emit('input', this.selectedValues);
     this.$emit('select', option);
   }

--- a/src/components/select/_select-single/script.ts
+++ b/src/components/select/_select-single/script.ts
@@ -8,7 +8,10 @@ import StSelectDropdown from '../_select-dropdown/index.vue';
 import StSelectDropdownScript from '../_select-dropdown/script';
 import StSelectBase from '../_select.base';
 import StIcon from '../../icon/index.vue';
-import { SelectOption } from '../types';
+import {
+  SelectOption,
+  SingleSelectValue,
+} from '../types';
 
 
 @Component({
@@ -21,7 +24,7 @@ import { SelectOption } from '../types';
 })
 export default class StSelectSingle extends StSelectBase {
   @Prop(String)
-  value!: string;
+  value!: SingleSelectValue;
 
   dropdownVisible: boolean = false;
 
@@ -31,7 +34,6 @@ export default class StSelectSingle extends StSelectBase {
       selected: this.selectedOption && this.selectedOption.value === option.value,
     }));
   }
-
 
   get selectedOption(): SelectOption | undefined {
     return this.options.find((option: SelectOption) => option && option.value === this.value);

--- a/src/components/select/_select.base.ts
+++ b/src/components/select/_select.base.ts
@@ -1,12 +1,27 @@
 import {
   Prop,
   Vue,
+  Watch,
 } from 'vue-property-decorator';
 
 import { DropdownBindProperties } from '../dropdown/types';
-import { SelectOption } from './types';
+import {
+  BaseSelectValue,
+  SelectOption,
+} from './types';
+
 
 export default class StSelectBase extends Vue {
+  @Prop()
+  value!: BaseSelectValue;
+
+  // Watch on `value` doesn't work in extended classes without this
+  @Watch('value')
+  onValueChange(): void {}
+
+  @Prop(Boolean)
+  multiple!: boolean;
+
   @Prop(Array)
   options!: SelectOption[];
 

--- a/src/components/select/script.ts
+++ b/src/components/select/script.ts
@@ -8,6 +8,7 @@ import StSelectMultipleScript from './_select-multiple/script';
 import StSelectSingle from './_select-single/index.vue';
 import StSelectSingleScript from './_select-single/script';
 import StSelectBase from './_select.base';
+import { BaseSelectValue } from './types';
 
 
 @Component({
@@ -19,10 +20,7 @@ import StSelectBase from './_select.base';
 })
 export default class StSelect extends StSelectBase {
   @Prop()
-  value!: (string | string[]);
-
-  @Prop(Boolean)
-  multiple!: boolean;
+  value!: BaseSelectValue;
 
   get componentName(): string {
     return `st-select-${this.multiple ? 'multiple' : 'single'}`;

--- a/src/components/select/types.ts
+++ b/src/components/select/types.ts
@@ -1,3 +1,7 @@
+export type BaseSelectValue = (SingleSelectValue | MultipleSelectValue);
+export type SingleSelectValue = string;
+export type MultipleSelectValue = string[];
+
 export interface SelectOption {
   label: string;
   value: string;


### PR DESCRIPTION
**Maintenance**
* Fixed multiple `Select`'s selected options update. There was a problem with displaying of collapser's items when `Select`'s value was changed from outside
* Created `BaseSelectValue`, `SingleSelectValue`, and `MultipleSelectValue` types for `Select` prop `value`  

**Bonus**
* Fixed checkbox height (container of checkbox's square was a bit higher)