### PR TITLE
TMC-581 | Fixed Input align problem in Safari and Mozilla

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.15
+
+### Maintenance
+* Fixed `Input`'s align problem in Safari and Mozilla
+
+
+
+
 ## 0.2.14
 
 ### Features

--- a/src/assets/scss/components/input/_variables.scss
+++ b/src/assets/scss/components/input/_variables.scss
@@ -21,6 +21,7 @@ $st-input-disabled-background: $st-disabled-fill !default;
 $st-input-color: $st-text-color-regular !default;
 $st-input-disabled-color: $st-disabled-text-color !default;
 
+$st-input-line-height: normal !default;
 $st-input-font-size: $st-font-size !default;
 $st-input-placeholder-color: $st-text-color-placeholder !default;
 $st-input-disabled-placeholder-color: $st-text-color-placeholder !default;

--- a/src/assets/scss/themes/offers/input.scss
+++ b/src/assets/scss/themes/offers/input.scss
@@ -6,7 +6,7 @@
 
   height: 42px;
   font-size: 14px;
-  line-height: 1;
+  line-height: normal;
   background-color: transparent;
   border-color: $st-color-pink-swan;
   border-radius: 2px;

--- a/src/components/input/style.scss
+++ b/src/components/input/style.scss
@@ -48,7 +48,7 @@
     height: 100%;
     padding: 0;
     font-size: $st-input-font-size;
-    line-height: 1;
+    line-height: $st-input-line-height;
     color: $st-input-color;
     cursor: inherit;
     -webkit-appearance: none;


### PR DESCRIPTION
**Maintenance**
* Fixed `Input`'s align problem in Safari and Mozilla